### PR TITLE
Feat : 상품 이미지 파일 업로드 기능 구현

### DIFF
--- a/src/main/java/com/pickx3/controller/WorkController.java
+++ b/src/main/java/com/pickx3/controller/WorkController.java
@@ -3,41 +3,53 @@ package com.pickx3.controller;
 import com.pickx3.domain.entity.work_package.Work;
 import com.pickx3.domain.entity.work_package.dto.WorkForm;
 import com.pickx3.domain.entity.work_package.dto.WorkUpdateForm;
+import com.pickx3.service.WorkImgService;
 import com.pickx3.service.WorkService;
 import com.pickx3.util.ApiResponseMessage;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
-@Api(tags = "상품 CRUD 컨트롤러")
+
+//@Tag(name = "상품 CRUD", description = "상품 관련 API")
+@Slf4j
 @RequestMapping("/works")
 @RestController
 public class WorkController {
     @Autowired
     private WorkService workService;
 
+    @Autowired
+    private WorkImgService workImgService;
+
     /*
     * 상품 등록
     * */
-    @ApiOperation(value = "상품 정보 저장", notes = "회원은 상품을 등록할 수 있다")
-    @PostMapping
-    public ResponseEntity<?> createWork(@RequestBody @Valid WorkForm workForm){
+//    @Operation(summary = "상품 정보 저장", description = "회원은 상품을 등록할 수 있다")
+    @PostMapping(consumes =  MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> createWork(@ModelAttribute WorkForm workForm){
         ApiResponseMessage result;
         HashMap data = new HashMap<>();
         try{
+            log.info("===========상품명=============" +  workForm.toString().toString());
             Work work = workService.createWork(workForm);
+            List<MultipartFile> files = workForm.getFiles();
+            workImgService.uploadWorkImg(files, work);
+
             data.put("workNum",work.getWorkNum());
             data.put("workerNum",work.getWorkNum());
             data.put("workName",work.getWorkName());
             data.put("workPrice",work.getWorkPrice());
             data.put("workDesc",work.getWorkDesc());
+            data.put("workImg", workForm.getFiles());
 
             result = new ApiResponseMessage(true, "Success", "200", "",data);
             return new ResponseEntity<>(result, HttpStatus.OK);
@@ -50,9 +62,9 @@ public class WorkController {
     /*
      * 회원별 상품 목록 조회
      * */
-    @ApiOperation(value = "회원별 상품 목록 조회", notes = "회원은 자신이 등록한 상품 목록을 조회 할 수 있다")
+//    @Operation(summary = "회원별 상품 목록 조회", description = "회원은 자신이 등록한 상품 목록을 조회 할 수 있다")
     @GetMapping("/users/{workerNum}")
-    public ResponseEntity<?> getWorks(@PathVariable(value = "workerNum") Long workerNum){
+    public ResponseEntity<?> getWorks(@Parameter(description = "회원 고유 ID", required = true, example = "1") @PathVariable(value = "workerNum") Long workerNum){
         ApiResponseMessage result;
         HashMap data = new HashMap<>();
         try{
@@ -70,7 +82,7 @@ public class WorkController {
    /*
     * 상품 상세정보 조회
     * */
-    @ApiOperation(value = "상품 상세 정보 조회", notes = "회원은 상품 상세 정보를 조회할 수 있다")
+//    @Operation(summary = "상품 상세 정보 조회", description = "회원은 상품 상세 정보를 조회할 수 있다")
     @GetMapping("/{workNum}")
     public ResponseEntity<?> getWorkInfo(@PathVariable(value = "workNum") Long workNum){
         ApiResponseMessage result;
@@ -88,7 +100,7 @@ public class WorkController {
     /*
      * 상품 정보 수정
      * */
-    @ApiOperation(value = "상품 정보 수정", notes = "회원은 상품정보를 수정 할 수 있다")
+//    @Operation(summary = "상품 정보 수정", description = "회원은 상품정보를 수정 할 수 있다")
     @PatchMapping
     public ResponseEntity<?> updateWork(@RequestBody @Valid WorkUpdateForm workUpdateForm){
         ApiResponseMessage result;
@@ -106,7 +118,7 @@ public class WorkController {
     /*
      * 상품 정보 수정
      * */
-    @ApiOperation(value = "상품 정보 삭제", notes = "회원은 상품정보를 삭제 할 수 있다")
+//    @Operation(summary = "상품 정보 삭제", description = "회원은 상품정보를 삭제 할 수 있다")
     @DeleteMapping("/{workNum}")
     public ResponseEntity<?> removeWork(@PathVariable(value = "workNum") Long workNum){
         ApiResponseMessage result;

--- a/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
@@ -1,22 +1,26 @@
 package com.pickx3.domain.entity.work_package;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
+import javax.persistence.*;
+
+@Getter @Setter
 @Entity
 public class WorkImg {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long workImgNum;
 
-    private Long workNum;
-
     private String workImgOriginName;
 
     private String workImgName;
 
     private String workImgSrcPath;
+
+    @ManyToOne
+    @JoinColumn(name = "workNum")
+    private Work work;
+
 
 }

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkForm.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkForm.java
@@ -1,24 +1,24 @@
 package com.pickx3.domain.entity.work_package.dto;
 
-import com.pickx3.domain.entity.work_package.Work;
-import lombok.Getter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Value;
-import org.springframework.boot.context.properties.bind.DefaultValue;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
+import java.util.List;
 
 
-@Getter
+@Data
 @NoArgsConstructor
+@ToString
 public class WorkForm {
     private Long workerNum;
 
-    @NotBlank(message = "상품명을 입력해주세요")
+//    @NotBlank(message = "상품명을 입력해주세요")
     private String workName;
 
     private String workDesc;
@@ -27,4 +27,7 @@ public class WorkForm {
     @Min(0)
     @NotNull(message="상품가격을 입력해 주세요")
     private int workPrice;
+
+    @Schema(title = "이미지 파일", description = "이미지 파일")
+    private List<MultipartFile> files;
 }

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkImgForm.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkImgForm.java
@@ -1,0 +1,27 @@
+package com.pickx3.domain.entity.work_package.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Schema
+@Getter
+@Setter
+public class WorkImgForm {
+    private String fileName;
+    private String fileOriginalName;
+    private String fileUrl;
+    private long size;
+
+    @Schema(title = "이미지 파일", description = "이미지 파일")
+    private List<MultipartFile> files;
+
+    public WorkImgForm(String fileName, String fileOriginalName, String fileUrl){
+        this.fileName = fileName;
+        this.fileOriginalName = fileOriginalName;
+        this.fileUrl = fileUrl;
+    }
+}

--- a/src/main/java/com/pickx3/domain/repository/WorkImgRepository.java
+++ b/src/main/java/com/pickx3/domain/repository/WorkImgRepository.java
@@ -1,0 +1,7 @@
+package com.pickx3.domain.repository;
+
+import com.pickx3.domain.entity.work_package.WorkImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkImgRepository extends JpaRepository<WorkImg, Long> {
+}

--- a/src/main/java/com/pickx3/service/WorkImgService.java
+++ b/src/main/java/com/pickx3/service/WorkImgService.java
@@ -1,0 +1,71 @@
+package com.pickx3.service;
+
+import com.pickx3.domain.entity.work_package.Work;
+import com.pickx3.domain.entity.work_package.WorkImg;
+import com.pickx3.domain.repository.WorkImgRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+
+@Service
+public class WorkImgService {
+
+    private String path = "C:\\dev\\teamProject\\pppick-backend\\src\\main\\resources\\img";
+    private Path uploadPath;
+
+    @Autowired
+    private WorkImgRepository workImgRepository;
+
+    public void uploadWorkImg(List<MultipartFile> files, Work work) {
+
+        uploadPath = Paths.get(path).toAbsolutePath().normalize();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddhhmmss_");
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        String timeStamp = sdf.format(timestamp);
+
+        for (MultipartFile file : files) {
+
+            String fileType = file.getContentType();
+            String originalFilename = file.getOriginalFilename();
+
+//           파일 타입이 png/jpeg가 아닐 경우  exception 처리
+            String fileName = timeStamp + StringUtils.cleanPath(file.getOriginalFilename());
+
+            try {
+                if (fileName.contains("..")) {
+                    //에러 발생
+                    throw new IllegalStateException("형식이 잘못되었습니다");
+                }
+
+                // Copy file to the target location (Replacing existing file with the same name)
+                Path targetLocation = this.uploadPath.resolve(fileName);
+                Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+                WorkImg workImg = new WorkImg();
+                workImg.setWork(work);
+                workImg.setWorkImgName(fileName);
+                workImg.setWorkImgOriginName(originalFilename);
+                workImg.setWorkImgSrcPath(targetLocation.toString());
+
+                workImgRepository.save(workImg);
+
+//                return fileName;
+            } catch (IOException ex) {
+                throw new IllegalStateException("파일이 저장되지않았습니다");
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
1. 상품 이미지 DTO 및 상품 정보와 상품 이미지 정보가 같이 있는 DTO 생성
2. 상품 이미지 레포지토리 생성
3. 상품 이미지 파일 업로드할 경우, 파일을 지정한 경로에 파일을 저장 후 테이블에 업로드된 파일 정보 저장
4. 상품 컨트롤러 수정
- 이전에는 상품 정보만 등록 가능 => 현재 상품 정보와 파일 정보를 같이 전달 받는다(WorkForm DTO 수정)
- 이미지 파일을 전달 받은 후, 이미지 서비스를 호출하여 파일을 서버에 저장