### PR TITLE
Feat:#18-이미지 목록 조회

### DIFF
--- a/src/main/java/com/pickx3/controller/WorkController.java
+++ b/src/main/java/com/pickx3/controller/WorkController.java
@@ -6,6 +6,7 @@ import com.pickx3.domain.entity.work_package.dto.WorkUpdateForm;
 import com.pickx3.service.WorkImgService;
 import com.pickx3.service.WorkService;
 import com.pickx3.util.ApiResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +34,7 @@ public class WorkController {
     /*
     * 상품 등록
     * */
-//    @Operation(summary = "상품 정보 저장", description = "회원은 상품을 등록할 수 있다")
+    @Operation(summary = "상품 정보 저장", description = "회원은 상품을 등록할 수 있다")
     @PostMapping(consumes =  MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> createWork(@ModelAttribute WorkForm workForm){
         ApiResponseMessage result;
@@ -49,7 +50,7 @@ public class WorkController {
             data.put("workName",work.getWorkName());
             data.put("workPrice",work.getWorkPrice());
             data.put("workDesc",work.getWorkDesc());
-            data.put("workImg", workForm.getFiles());
+//            data.put("workImg", workForm.getFiles());
 
             result = new ApiResponseMessage(true, "Success", "200", "",data);
             return new ResponseEntity<>(result, HttpStatus.OK);
@@ -59,10 +60,12 @@ public class WorkController {
         }
     }
 
-    /*
+    /**
      * 회원별 상품 목록 조회
-     * */
-//    @Operation(summary = "회원별 상품 목록 조회", description = "회원은 자신이 등록한 상품 목록을 조회 할 수 있다")
+     * @param workerNum
+     * @return
+     */
+    @Operation(summary = "회원별 상품 목록 조회", description = "회원은 자신이 등록한 상품 목록을 조회 할 수 있다")
     @GetMapping("/users/{workerNum}")
     public ResponseEntity<?> getWorks(@Parameter(description = "회원 고유 ID", required = true, example = "1") @PathVariable(value = "workerNum") Long workerNum){
         ApiResponseMessage result;
@@ -79,10 +82,13 @@ public class WorkController {
         }
     }
 
-   /*
-    * 상품 상세정보 조회
-    * */
-//    @Operation(summary = "상품 상세 정보 조회", description = "회원은 상품 상세 정보를 조회할 수 있다")
+
+    /**
+     * 상품 상세정보 조회
+     * @param workNum
+     * @return
+     */
+    @Operation(summary = "상품 상세 정보 조회", description = "회원은 상품 상세 정보를 조회할 수 있다")
     @GetMapping("/{workNum}")
     public ResponseEntity<?> getWorkInfo(@PathVariable(value = "workNum") Long workNum){
         ApiResponseMessage result;
@@ -97,10 +103,13 @@ public class WorkController {
         }
      }
 
-    /*
+
+    /**
      * 상품 정보 수정
-     * */
-//    @Operation(summary = "상품 정보 수정", description = "회원은 상품정보를 수정 할 수 있다")
+     * @param workUpdateForm
+     * @return
+     */
+    @Operation(summary = "상품 정보 수정", description = "회원은 상품정보를 수정 할 수 있다")
     @PatchMapping
     public ResponseEntity<?> updateWork(@RequestBody @Valid WorkUpdateForm workUpdateForm){
         ApiResponseMessage result;
@@ -115,10 +124,12 @@ public class WorkController {
         }
     }
 
-    /*
-     * 상품 정보 수정
-     * */
-//    @Operation(summary = "상품 정보 삭제", description = "회원은 상품정보를 삭제 할 수 있다")
+    /**
+     * 상품 정보 삭제
+     * @param workNum
+     * @return
+     */
+    @Operation(summary = "상품 정보 삭제", description = "회원은 상품정보를 삭제 할 수 있다")
     @DeleteMapping("/{workNum}")
     public ResponseEntity<?> removeWork(@PathVariable(value = "workNum") Long workNum){
         ApiResponseMessage result;

--- a/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
@@ -1,11 +1,13 @@
 package com.pickx3.domain.entity.work_package;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 
-@Getter @Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class WorkImg {
     @Id

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkDetailDTO.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkDetailDTO.java
@@ -1,0 +1,23 @@
+package com.pickx3.domain.entity.work_package.dto;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@ToString
+public class WorkDetailDTO {
+    private Long workerNum;
+
+    private String workName;
+
+    private String workDesc;
+
+    private int workPrice;
+
+    private List<WorkImgForm> workImages;
+}

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkImgForm.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/WorkImgForm.java
@@ -1,5 +1,6 @@
 package com.pickx3.domain.entity.work_package.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,17 +12,18 @@ import java.util.List;
 @Getter
 @Setter
 public class WorkImgForm {
-    private String fileName;
-    private String fileOriginalName;
-    private String fileUrl;
+    private String workImgName;
+    private String workImgOriginName;
+    private String workImgSrcPath;
     private long size;
 
+    @JsonIgnore
     @Schema(title = "이미지 파일", description = "이미지 파일")
     private List<MultipartFile> files;
 
-    public WorkImgForm(String fileName, String fileOriginalName, String fileUrl){
-        this.fileName = fileName;
-        this.fileOriginalName = fileOriginalName;
-        this.fileUrl = fileUrl;
+    public WorkImgForm(String workImgName, String workImgOriginName, String workImgSrcPath){
+        this.workImgName = workImgName;
+        this.workImgOriginName = workImgOriginName;
+        this.workImgSrcPath = workImgSrcPath;
     }
 }

--- a/src/main/java/com/pickx3/domain/repository/WorkImgRepository.java
+++ b/src/main/java/com/pickx3/domain/repository/WorkImgRepository.java
@@ -1,7 +1,12 @@
 package com.pickx3.domain.repository;
 
 import com.pickx3.domain.entity.work_package.WorkImg;
+import com.pickx3.domain.entity.work_package.dto.WorkImgForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WorkImgRepository extends JpaRepository<WorkImg, Long> {
+
+    List<WorkImgForm> findByWork_workNum(Long workNum);
 }

--- a/src/main/java/com/pickx3/service/WorkImgService.java
+++ b/src/main/java/com/pickx3/service/WorkImgService.java
@@ -2,6 +2,7 @@ package com.pickx3.service;
 
 import com.pickx3.domain.entity.work_package.Work;
 import com.pickx3.domain.entity.work_package.WorkImg;
+import com.pickx3.domain.entity.work_package.dto.WorkImgForm;
 import com.pickx3.domain.repository.WorkImgRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,9 @@ public class WorkImgService {
     @Autowired
     private WorkImgRepository workImgRepository;
 
+    /**
+     * 상품 이미지 업로드
+     */
     public void uploadWorkImg(List<MultipartFile> files, Work work) {
 
         uploadPath = Paths.get(path).toAbsolutePath().normalize();
@@ -49,23 +53,35 @@ public class WorkImgService {
                     throw new IllegalStateException("형식이 잘못되었습니다");
                 }
 
-                // Copy file to the target location (Replacing existing file with the same name)
+                // target location에서 파일 복사
                 Path targetLocation = this.uploadPath.resolve(fileName);
                 Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 
-                WorkImg workImg = new WorkImg();
-                workImg.setWork(work);
-                workImg.setWorkImgName(fileName);
-                workImg.setWorkImgOriginName(originalFilename);
-                workImg.setWorkImgSrcPath(targetLocation.toString());
+                WorkImg workImg = WorkImg.builder()
+                        .workImgName(fileName)
+                        .workImgOriginName(originalFilename)
+                        .workImgSrcPath(targetLocation.toString())
+                        .work(work)
+                        .build();
 
                 workImgRepository.save(workImg);
+
+                file.getInputStream().close();
 
 //                return fileName;
             } catch (IOException ex) {
                 throw new IllegalStateException("파일이 저장되지않았습니다");
             }
         }
+    }
+
+    /**
+     * 상품 이미지 목록 조회
+     * @param workNum
+     * @return
+     */
+    public List<WorkImgForm> getWorkImages(Long workNum){
+        return workImgRepository.findByWork_workNum(workNum);
     }
 
 }

--- a/src/main/java/com/pickx3/service/WorkService.java
+++ b/src/main/java/com/pickx3/service/WorkService.java
@@ -2,22 +2,28 @@ package com.pickx3.service;
 
 import com.pickx3.domain.entity.user_package.User;
 import com.pickx3.domain.entity.work_package.Work;
+import com.pickx3.domain.entity.work_package.dto.WorkDetailDTO;
 import com.pickx3.domain.entity.work_package.dto.WorkForm;
+import com.pickx3.domain.entity.work_package.dto.WorkImgForm;
 import com.pickx3.domain.entity.work_package.dto.WorkUpdateForm;
 import com.pickx3.domain.repository.UserRepository;
+import com.pickx3.domain.repository.WorkImgRepository;
 import com.pickx3.domain.repository.WorkRepository;
-import net.bytebuddy.asm.MemberRemoval;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Transactional
 @Service
 public class WorkService {
     @Autowired
     private WorkRepository workRepository;
+    @Autowired
+    private WorkImgRepository workImgRepository;
     @Autowired
     private UserRepository userRepository;
 
@@ -25,6 +31,7 @@ public class WorkService {
     * 상품 등록
     * */
     public Work createWork(WorkForm workForm){
+        log.info("==========user===========" +workForm.getWorkerNum());
         User user = userRepository.findById(workForm.getWorkerNum()).get();
 
         Work work = Work.builder()
@@ -48,8 +55,19 @@ public class WorkService {
     /*
      * 상품 상세정보 조회
      * */
-    public Work getWorkInfo(Long workNum){
-        return workRepository.findById(workNum).get();
+    public WorkDetailDTO getWorkInfo(Long workNum){
+        Work work = workRepository.findById(workNum).get();
+        List<WorkImgForm> workImages = workImgRepository.findByWork_workNum(workNum);
+
+        log.info("상품 이미지 정보" + workImages.get(0).getWorkImgName());
+        WorkDetailDTO workDetailDTO = new WorkDetailDTO();
+        workDetailDTO.setWorkerNum(work.getWorkNum());
+        workDetailDTO.setWorkName(work.getWorkName());
+        workDetailDTO.setWorkDesc(work.getWorkDesc());
+        workDetailDTO.setWorkPrice(work.getWorkPrice());
+        workDetailDTO.setWorkImages(workImages);
+
+        return workDetailDTO;
     }
 
     /*

--- a/src/test/java/com/pickx3/domain/repository/WorkImgRepositoryTest.java
+++ b/src/test/java/com/pickx3/domain/repository/WorkImgRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.pickx3.domain.repository;
+
+import com.pickx3.domain.entity.user_package.User;
+import com.pickx3.domain.entity.work_package.Work;
+import com.pickx3.domain.entity.work_package.WorkImg;
+import com.pickx3.domain.entity.work_package.dto.WorkImgForm;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+@Rollback(value = false)
+class WorkImgRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private WorkRepository workRepository;
+    @Autowired
+    private WorkImgRepository workImgRepository;
+
+    @Test
+    public void 상품이미지목록조회(){
+
+        List<WorkImg> workImgs = 상품이미지목록생성();
+
+        List<WorkImgForm> result = workImgRepository.findByWork_workNum(7L);
+
+        System.out.println("상품정보 "+result.get(0).getWorkImgName());
+
+        assertEquals(5, result.size() );
+    }
+
+    public User 회원생성(){
+        User user = User.builder()
+                .email("test@naver.com")
+                .name("test")
+                .nickName("test")
+                .build();
+
+        userRepository.save(user);
+        return user;
+    }
+
+    public Work 상품생성(){
+        User user = 회원생성();
+        Work work = Work.builder()
+                .workName("상품1")
+                .workDesc("상품설명1")
+                .workPrice(30000)
+                .userInfo(user)
+                .build();
+        workRepository.save(work);
+        return work;
+    }
+
+    public List<WorkImg> 상품이미지목록생성(){
+        Work work = 상품생성();
+
+        List<WorkImg> workImgs = new ArrayList<>();
+
+        for(int i = 0; i < 5; i++){
+            WorkImg workImg = WorkImg.builder()
+                    .workImgName("20230211-test" + i)
+                    .workImgOriginName("test" + i)
+                    .workImgSrcPath("/dev/resource/img" + i)
+                    .work(work)
+                    .build();
+
+            workImgRepository.save(workImg);
+            workImgs.add(workImg);
+        }
+
+        return workImgs;
+
+    }
+}


### PR DESCRIPTION
1. 상품아이디를 통해 상품의 이미지 목록 조회 기능 추가
2. 상품 상세 정보 조회 시 이미지 목록도 같이 전달되게 수정
3. 2의 작업을 위해, 상품정보 + 상품 이미지를 저장하는 WorkDetailDTO 생성