### PR TITLE
fix: 상품별 이미지 목록 삭제

### DIFF
--- a/src/main/java/com/pickx3/controller/WorkController.java
+++ b/src/main/java/com/pickx3/controller/WorkController.java
@@ -134,6 +134,7 @@ public class WorkController {
     public ResponseEntity<?> removeWork(@PathVariable(value = "workNum") Long workNum){
         ApiResponseMessage result;
         try{
+            workImgService.removeWorkImages(workNum);
             workService.removeWork(workNum);
             result = new ApiResponseMessage(true, "Success" ,"200", "", null );
             return new ResponseEntity<>(result, HttpStatus.OK);

--- a/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/WorkImg.java
@@ -5,6 +5,7 @@ import lombok.*;
 import javax.persistence.*;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/work/WorkImgForm.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/work/WorkImgForm.java
@@ -12,6 +12,8 @@ import java.util.List;
 @Getter
 @Setter
 public class WorkImgForm {
+    private Long workImgNum;
+
     private String workImgName;
     private String workImgOriginName;
     private String workImgSrcPath;
@@ -21,7 +23,8 @@ public class WorkImgForm {
     @Schema(title = "이미지 파일", description = "이미지 파일")
     private List<MultipartFile> files;
 
-    public WorkImgForm(String workImgName, String workImgOriginName, String workImgSrcPath){
+    public WorkImgForm(Long workImgNum, String workImgName, String workImgOriginName, String workImgSrcPath){
+        this.workImgNum = workImgNum;
         this.workImgName = workImgName;
         this.workImgOriginName = workImgOriginName;
         this.workImgSrcPath = workImgSrcPath;

--- a/src/main/java/com/pickx3/service/WorkImgService.java
+++ b/src/main/java/com/pickx3/service/WorkImgService.java
@@ -82,7 +82,7 @@ public class WorkImgService {
     }
 
     /**
-     * 상품 이미지 삭제
+     * 상품 이미지 단일 삭제
      * @param workImgNum
      */
     public void removeWorkImage(Long workImgNum){
@@ -98,7 +98,32 @@ public class WorkImgService {
         }catch (IOException e){
             e.printStackTrace();
         }
+    }
 
+    /**
+     * 상품의 이미지 목록 삭제
+     * @param workNum
+     */
+    public void removeWorkImages(Long workNum){
+        List<WorkImgForm> images =  workImgRepository.findByWork_workNum(workNum);
 
+        try{
+            for(WorkImgForm workImgForm : images){
+                WorkImg workImg = new WorkImg();
+
+                workImg.setWorkImgNum(workImgForm.getWorkImgNum());
+                workImg.setWorkImgName(workImgForm.getWorkImgName());
+                workImg.setWorkImgName(workImgForm.getWorkImgName());
+                workImg.setWorkImgOriginName(workImgForm.getWorkImgOriginName());
+                workImg.setWorkImgSrcPath(workImgForm.getWorkImgSrcPath());
+
+                Path filePath = Paths.get(workImgForm.getWorkImgSrcPath());
+                Files.delete(filePath);
+
+                workImgRepository.delete(workImg);
+            }
+        }catch (Exception e){
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
- 상품 아이디를 통해 해당 상품의 이미지 목록을 삭제한다
- 상품 삭제 시, 외래키 제약조건이 있어 상품 이미지를 먼저 삭제해야한다