### PR TITLE
Feat: #30- 상품 목록 조회 시 이미지 정보도 같이 조회

### DIFF
--- a/src/main/java/com/pickx3/controller/WorkController.java
+++ b/src/main/java/com/pickx3/controller/WorkController.java
@@ -2,6 +2,7 @@ package com.pickx3.controller;
 
 import com.pickx3.domain.entity.work_package.Work;
 import com.pickx3.domain.entity.work_package.dto.work.WorkForm;
+import com.pickx3.domain.entity.work_package.dto.work.WorkResponseDTO;
 import com.pickx3.domain.entity.work_package.dto.work.WorkUpdateForm;
 import com.pickx3.service.WorkImgService;
 import com.pickx3.service.WorkService;
@@ -46,7 +47,7 @@ public class WorkController {
             workImgService.uploadWorkImg(files, work);
 
             data.put("workNum",work.getWorkNum());
-            data.put("workerNum",work.getWorkNum());
+            data.put("workerNum",work.getUserInfo().getId());
             data.put("workName",work.getWorkName());
             data.put("workPrice",work.getWorkPrice());
             data.put("workDesc",work.getWorkDesc());
@@ -71,7 +72,7 @@ public class WorkController {
         ApiResponseMessage result;
         HashMap data = new HashMap<>();
         try{
-            List<Work> works = workService.getWorks(workerNum);
+            List<WorkResponseDTO> works = workService.getWorks(workerNum);
             data.put("works",works);
 
             result = new ApiResponseMessage(true, "Success", "200", "",data);

--- a/src/main/java/com/pickx3/domain/entity/work_package/dto/work/WorkResponseDTO.java
+++ b/src/main/java/com/pickx3/domain/entity/work_package/dto/work/WorkResponseDTO.java
@@ -1,0 +1,23 @@
+package com.pickx3.domain.entity.work_package.dto.work;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+
+@Data
+@NoArgsConstructor
+@ToString
+public class WorkResponseDTO {
+    private Long workerNum;
+
+    private String workName;
+
+    private String workDesc;
+
+    private int workPrice;
+
+    private List<WorkImgForm> files;
+}

--- a/src/main/java/com/pickx3/service/WorkImgService.java
+++ b/src/main/java/com/pickx3/service/WorkImgService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.sql.Timestamp;
@@ -19,7 +20,10 @@ import java.util.List;
 @Service
 public class WorkImgService {
 
-    private String path = "C:\\dev\\teamProject\\pppick-backend\\src\\main\\resources\\img";
+
+//    private String path = "C:\\dev\\teamProject\\pppick-backend\\src\\main\\resources\\img";
+    private String path = new File("").getAbsolutePath()+File.separator+"images"+File.separator+"work";
+    Path directoryPath = Paths.get(path);
     private Path uploadPath;
 
     @Autowired
@@ -29,6 +33,7 @@ public class WorkImgService {
      * 상품 이미지 업로드
      */
     public void uploadWorkImg(List<MultipartFile> files, Work work) {
+
 
         uploadPath = Paths.get(path).toAbsolutePath().normalize();
 
@@ -49,6 +54,13 @@ public class WorkImgService {
                     //에러 발생
                     throw new IllegalStateException("형식이 잘못되었습니다");
                 }
+
+                if (!Files.isDirectory(directoryPath)) {
+                    System.out.println("디렉토리가 존재하지않습니다");
+                    Files.createDirectory(directoryPath);
+                }
+
+
 
                 // target location에서 파일 복사
                 Path targetLocation = this.uploadPath.resolve(fileName);

--- a/src/main/java/com/pickx3/service/WorkService.java
+++ b/src/main/java/com/pickx3/service/WorkService.java
@@ -2,10 +2,7 @@ package com.pickx3.service;
 
 import com.pickx3.domain.entity.user_package.User;
 import com.pickx3.domain.entity.work_package.Work;
-import com.pickx3.domain.entity.work_package.dto.work.WorkDetailDTO;
-import com.pickx3.domain.entity.work_package.dto.work.WorkForm;
-import com.pickx3.domain.entity.work_package.dto.work.WorkImgForm;
-import com.pickx3.domain.entity.work_package.dto.work.WorkUpdateForm;
+import com.pickx3.domain.entity.work_package.dto.work.*;
 import com.pickx3.domain.repository.UserRepository;
 import com.pickx3.domain.repository.WorkImgRepository;
 import com.pickx3.domain.repository.WorkRepository;
@@ -14,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -48,8 +46,23 @@ public class WorkService {
     /*
      * 회원별 상품 목록 조회
      * */
-    public List<Work> getWorks(Long workerNum){
-        return workRepository.findByUserInfo_id(workerNum);
+    public List<WorkResponseDTO> getWorks(Long workerNum){
+        List<WorkResponseDTO> dtos = new ArrayList<>();
+
+        List<Work> works = workRepository.findByUserInfo_id(workerNum);
+        for(Work work : works){
+            WorkResponseDTO dto = new WorkResponseDTO();
+            dto.setWorkName(work.getWorkName());
+            dto.setWorkDesc(work.getWorkDesc());
+            dto.setWorkPrice(work.getWorkPrice());
+
+            List<WorkImgForm> workImgs = workImgRepository.findByWork_workNum(work.getWorkNum());
+            dto.setFiles(workImgs);
+
+            dtos.add(dto);
+
+        }
+        return dtos;
     }
     
     /*


### PR DESCRIPTION
1. 기존 상품 목록 조회 시 상품 정보만 출력 => 상품 정보 + 상품 이미지 정보도 같이 조회
2. 상품 이미지 업로드 이슈 발생
- 디렉토리 경로를 인식 못하여 디렉토리가 생성안되서 400 오류 발생
- java io를 통해 파일 업로드 로직 수정